### PR TITLE
build(deps): bump kotlin_version from 1.4.30-M1 to 1.4.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.30-M1'
+    ext.kotlin_version = '1.4.30'
     ext.dokka_version = '1.4.20'
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
Bumps `kotlin_version` from 1.4.30-M1 to 1.4.30.

Updates `kotlin-gradle-plugin` from 1.4.30-M1 to 1.4.30
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.4.30-M1...v1.4.30)

Updates `kotlin-stdlib-jdk7` from 1.4.30-M1 to 1.4.30
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v1.4.30-M1...v1.4.30)

Signed-off-by: dependabot[bot] <support@github.com>