### PR TITLE
build(deps): bump gradle from 4.0.2 to 4.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
     }


### PR DESCRIPTION
Bumps gradle from 4.0.2 to 4.1.2.

Signed-off-by: dependabot[bot] <support@github.com>